### PR TITLE
Fix usage of heat templates with horizon

### DIFF
--- a/cloudinit/userExample.yaml
+++ b/cloudinit/userExample.yaml
@@ -19,8 +19,6 @@ parameters:
   type: comma_delimited_list
  public_network:
   type: string
-  constraints:
-    - custom_constraint: neutron.network
   default: ext-net 
  
 resources:

--- a/create-security-groups/singleMachineDevEnv.yaml
+++ b/create-security-groups/singleMachineDevEnv.yaml
@@ -21,8 +21,6 @@ parameters:
   public_network:
     type: string
     default: ext-net
-    constraints:
-      - custom_constraint: neutron.network
   ip_whitelist:
     type: string
     description: ip address or range in CIDR

--- a/create-security-groups/singleMachineProdEnv.yaml
+++ b/create-security-groups/singleMachineProdEnv.yaml
@@ -20,8 +20,6 @@ parameters:
   public_network:
     type: string
     default: ext-net
-    constraints:
-      - custom_constraint: neutron.network
   ip_whitelist:
     type: string
     constraints:

--- a/example-setup/clustersetup.yaml
+++ b/example-setup/clustersetup.yaml
@@ -26,8 +26,7 @@ parameters:
     default: 1
   public_network:
     type: string
-    constraints:
-      - custom_constraint: neutron.network
+    default: ext-net
   flavor_lb:
     type: string
     default: m1.micro

--- a/kickstart/kickstart.yaml
+++ b/kickstart/kickstart.yaml
@@ -33,8 +33,6 @@ parameters:
   public_network:
     type: string
     default: ext-net
-    constraints:
-      - custom_constraint: neutron.network
 
 resources:
 

--- a/lamp-single-server/example.yaml
+++ b/lamp-single-server/example.yaml
@@ -20,8 +20,6 @@ parameters:
   public_network:
     type: string
     default: ext-net 
-    constraints:
-      - custom_constraint: neutron.network
   image:
     type: string
     default: Ubuntu Xenial 16.04 (2019-03-27)

--- a/lbaas/lbstack.yaml
+++ b/lbaas/lbstack.yaml
@@ -34,8 +34,6 @@ parameters:
     type: string
     description: Network used by the load balancer
     default: ext-net 
-    constraints:
-      - custom_constraint: neutron.network
   number_upstreams:
     type: string
     default: 4

--- a/multiple-ssh-keys/server.yaml
+++ b/multiple-ssh-keys/server.yaml
@@ -15,8 +15,6 @@ parameters:
   public_network:
     type: string
     default: ext-net
-    constraints:
-      - custom_constraint: neutron.network
 
 resources:
   allow_ssh:

--- a/networks/1.single-network.yaml
+++ b/networks/1.single-network.yaml
@@ -6,8 +6,6 @@ parameters:
   public_network:
     type: string
     default: ext-net 
-    constraints:
-      - custom_constraint: neutron.network
 
 resources:
 

--- a/networks/2.two-networks.yaml
+++ b/networks/2.two-networks.yaml
@@ -6,8 +6,6 @@ parameters:
   public_network:
     type: string
     default: ext-net 
-    constraints:
-      - custom_constraint: neutron.network
 
 resources:
 

--- a/reserve-floating-ips/1.1_reserve_floating_ips.yaml
+++ b/reserve-floating-ips/1.1_reserve_floating_ips.yaml
@@ -6,8 +6,6 @@ parameters:
   public_network:
     type: string
     default: ext-net 
-    constraints:
-      - custom_constraint: neutron.network
   number_of_fips: 
     type: number
     default: 4

--- a/reserve-floating-ips/1.2_reserve_fip.yaml
+++ b/reserve-floating-ips/1.2_reserve_fip.yaml
@@ -5,8 +5,7 @@ description: Reserve permanent fip
 parameters:
   public_network:
     type: string
-    constraints:
-      - custom_constraint: neutron.network
+    default: ext-net
 
 resources:
   fip:

--- a/shared-volume/stack.yaml
+++ b/shared-volume/stack.yaml
@@ -9,8 +9,6 @@ parameters:
   public_network:
     type: string
     default: ext-net 
-    constraints:
-      - custom_constraint: neutron.network
   volume_id:
     type: string
     constraints:

--- a/single-server-from-snapshot/snapshot_image_example.yaml
+++ b/single-server-from-snapshot/snapshot_image_example.yaml
@@ -11,8 +11,6 @@ parameters:
   public_network:
     type: string
     default: ext-net
-    constraints:
-      - custom_constraint: neutron.network
   key_name:
     type: string
     constraints:

--- a/single-server-from-snapshot/snapshot_volume_example.yaml
+++ b/single-server-from-snapshot/snapshot_volume_example.yaml
@@ -11,8 +11,6 @@ parameters:
   public_network:
     type: string
     default: ext-net
-    constraints:
-      - custom_constraint: neutron.network
   key_name:
     type: string
     constraints:

--- a/single-server-on-local-storage/example.yaml
+++ b/single-server-on-local-storage/example.yaml
@@ -11,8 +11,6 @@ parameters:
   public_network:
     type: string
     default: ext-net
-    constraints:
-      - custom_constraint: neutron.network
   flavor:
     type: string
     constraints:

--- a/single-server-with-existing-floating-ip/example.yaml
+++ b/single-server-with-existing-floating-ip/example.yaml
@@ -12,8 +12,7 @@ description: Stack that launches a single server
 parameters:
   public_network:
     type: string
-    constraints:
-      - custom_constraint: neutron.network
+    default: ext-net
   floating_ip:
     type: string
     constraints:

--- a/single-server-with-existing-network/example.yaml
+++ b/single-server-with-existing-network/example.yaml
@@ -12,8 +12,7 @@ description: Stack that launches a single server
 parameters:
   public_network:
     type: string
-    constraints:
-      - custom_constraint: neutron.network
+    default: ext-net
   net:
     type: string
     constraints:

--- a/single-server-with-existing-security-group/example.yaml
+++ b/single-server-with-existing-security-group/example.yaml
@@ -12,8 +12,7 @@ description: Stack that launches a single server
 parameters:
   public_network:
     type: string
-    constraints:
-      - custom_constraint: neutron.network
+    default: ext-net
   security_group:
     type: string
     constraints:

--- a/single-server-with-multiple-volumes/example.yaml
+++ b/single-server-with-multiple-volumes/example.yaml
@@ -12,8 +12,7 @@ description: Stack that launches a single server
 parameters:
   public_network:
     type: string
-    constraints:
-      - custom_constraint: neutron.network
+    default: ext-net
   image:
     type: string
     constraints:

--- a/subnet-connect/subnetConnect.yaml
+++ b/subnet-connect/subnetConnect.yaml
@@ -10,8 +10,6 @@ parameters:
   public_network:
     type: string
     default: ext-net 
-    constraints:
-      - custom_constraint: neutron.network
   key_name:
     type: string
     constraints:


### PR DESCRIPTION
When using a heat template with horizon, the
neutron.network validator led to a dropdown in horizon
where ext-net was not one of the options.

That made all heat templates unusable in horizon.