### PR TITLE
In kickstart stack: fix floating IP creation

### DIFF
--- a/kickstart/kickstart.yaml
+++ b/kickstart/kickstart.yaml
@@ -227,7 +227,7 @@ resources:
 
   floating_ip:
     type: OS::Neutron::FloatingIP
-    depends_on: [ port ]
+    depends_on: [ port, router_subnet_bridge ]
     properties:
       floating_network: { get_param: public_network }
       port_id: { get_resource: port }


### PR DESCRIPTION
The floating_ip resource needs both the port and the router interface,
otherwise it sometimes fails with an error like
"External network ffd19224-39d9-4352-9539-7870807b11a6 is not reachable
from subnet 80ccadc2-64e7-46b3-84a0-557f9655c2de.
Therefore, cannot associate Port 1a65d68d-22a6-4d69-9ac0-e5415516cf30
with a Floating IP."
Added the dependency on router_subnet_bridge to floating_ip.